### PR TITLE
music synced

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -66,7 +66,6 @@ module.exports = function mysql(file, data, cb){
     data = {};
   }
 
-
   let query = Fs.readFileSync(
     file,
     { encoding: "utf8" }

--- a/mappings/editorial.js
+++ b/mappings/editorial.js
@@ -6,7 +6,7 @@ const Helpers = require("./util/helpers");
 module.exports = function(doc){
   let tags = Helpers.getTags(doc.field_id_1028);
 
-  let images = Helpers.getImages(doc.entry_id, doc.field_id_664, "col_id_218");
+  let images = Helpers.getFiles(doc.entry_id, doc.field_id_664, "da.col_id_218");
 
   const date = Helpers.getDate(doc.day, doc.month, doc.year);
 

--- a/mappings/editorial.sql
+++ b/mappings/editorial.sql
@@ -41,4 +41,4 @@ OR
 OR
   /* news */
   d.channel_id = 115
-LIMIT 50
+LIMIT 1

--- a/mappings/music.js
+++ b/mappings/music.js
@@ -1,0 +1,137 @@
+"use strict";
+
+const Helpers = require("./util/helpers");
+
+
+module.exports = function(doc){
+
+  let tracks = [
+    "col_id_246 as title",
+    "col_id_247 as duration",
+    "col_id_248 as file"
+  ].join(",\n");
+
+  let downloads = [
+    "col_id_209 as title",
+    "col_id_210 as file"
+  ].join(",\n");
+
+  let links = [
+    "col_id_245 as link",
+    "col_id_417 as cta"
+  ].join(",\n");
+
+  const image = Helpers.getFile(doc.entry_id, doc.album_image, "f.file_name");
+  const blurredImage = Helpers.getFile(doc.entry_id, doc.album_blurred_image, "f.file_name");
+  const date = Helpers.getDate(doc.day, doc.month, doc.year);
+
+  // track files and data from matrix
+  tracks = Helpers.getMatrixData(doc.entry_id, tracks);
+  tracks = tracks.map(track => {
+
+    // lookup s3 link
+    if (track.file) {
+      track.file = Helpers.getFile(
+        doc.entry_id, track.file, "f.file_name"
+      )[0].s3;
+    }
+
+    return {
+      title: track.title,
+      duration: track.duration,
+      file: track.file
+    }
+  }).filter(track => {
+    return track.title && track.duration && track.file
+  });
+
+  // download files and titles from matrix
+  downloads = Helpers.getMatrixData(doc.entry_id, downloads);
+  downloads = downloads.map(download => {
+
+    // lookup s3 link
+    if (download.file) {
+      download.file = Helpers.getFile(
+        doc.entry_id, download.file, "f.file_name"
+      )[0].s3;
+    }
+
+    return {
+      title: download.title,
+      file: download.file
+    }
+  }).filter(download => {
+    return download.title && download.file
+  });
+
+
+  // links ctas and urls
+  links = Helpers.getMatrixData(doc.entry_id, links);
+  links = links.map(link => {
+    return {
+      link: link.link,
+      cta: link.cta
+    }
+  }).filter(link => {
+    return link.link && link.cta
+  });
+
+
+  let cleanedData = {
+    entryId: doc.entry_id,
+    siteId: doc.site_id,
+    channelName: doc.channel_name,
+    title: doc.title,
+    status: doc.status,
+    image: image[0].cloudfront,
+    blurredImage: blurredImage[0].cloudfront,
+    meta: {
+      date: date,
+      channelId: doc.channel_id
+    },
+    tracks: tracks,
+    downloads: downloads,
+    links: links
+  }
+
+  return cleanedData;
+
+};
+
+
+module.exports.identifier = "entry_id"
+module.exports.collection = "music";
+
+module.exports.schema = {
+  entryId: String,      // entry_id
+  siteId: String,       // site_id
+  channelName: String,  // channel_name
+  status: String,       // status
+  title: String,        // title
+  image: String,
+  blurredImage: String,
+  meta: {
+    date: Date,         //
+    channelId: String   // channel_id
+  },
+  tracks: [{
+    title: String,
+    duration: String,
+    file: String
+  }],
+  downloads: [{
+    title: String,
+    file: String
+  }],
+  links: [{
+    cta: String,
+    link: String
+  }]
+}
+
+
+module.exports.triggers = [
+  { table: "exp_channel_data" },
+  { table: "exp_channel_titles" },
+  { table: "exp_channels" }
+];

--- a/mappings/music.sql
+++ b/mappings/music.sql
@@ -1,0 +1,28 @@
+SELECT
+  d.entry_id,
+  d.site_id,
+  d.channel_id,
+  d.field_id_249 as album_image,
+  d.field_id_1124 as album_blurred_image,
+  d.field_id_250 as album_description,
+  d.field_id_251 as album_itunes,
+  d.field_id_689 as album_tracks,
+  d.field_id_687 as album_links,
+  d.field_id_646 as album_downloads,
+  d.field_id_1196 as album_study,
+  c.channel_name,
+  t.title,
+  t.status,
+  t.year,
+  t.month,
+  t.day
+FROM
+  escId(exp_channel_data) AS d
+LEFT JOIN
+  exp_channels as c
+    ON d.channel_id = c.channel_id
+LEFT JOIN
+  exp_channel_titles AS t
+    ON d.entry_id = t.entry_id
+WHERE
+  d.channel_id = 47

--- a/mappings/promotion.js
+++ b/mappings/promotion.js
@@ -8,7 +8,7 @@ module.exports = function(doc){
 
   const summary = Helpers.cleanMarkup(doc.summary);
 
-  const images = Helpers.getImages(doc.entry_id, doc.positions, "col_id_343");
+  const images = Helpers.getFiles(doc.entry_id, doc.positions, "da.col_id_343");
 
   let cleanedData = {
     entryId: doc.entry_id,

--- a/mappings/promotion.sql
+++ b/mappings/promotion.sql
@@ -22,3 +22,4 @@ LEFT JOIN
     ON d.entry_id = t.entry_id
 WHERE
   d.channel_id = 160
+LIMIT 1

--- a/mappings/util/images.sql
+++ b/mappings/util/images.sql
@@ -1,5 +1,5 @@
 SELECT
-  da.${positionColumn} as position,
+  ${positionColumn} as position,
   c.col_name as image_type,
   c.col_label as image_label,
   f.file_name,
@@ -28,4 +28,4 @@ LEFT JOIN
 WHERE
   d.entry_id=${entryId}
 AND
-  da.${positionColumn}="${imageName}"
+  ${positionColumn}="${imageName}"

--- a/mappings/util/matrix.sql
+++ b/mappings/util/matrix.sql
@@ -1,0 +1,6 @@
+SELECT
+  ${fields}
+FROM
+  exp_matrix_data
+WHERE
+  entry_id = ${entryId}


### PR DESCRIPTION
@johnthepink this adjusts the getImages helper to become getFiles where you can specify a pivot column + id (still listed as position in the args).

It also brings over all of the data needed for music. This does break convention naming wise because it isn't named by channel (Resources for Churches) but instead by `music`. I'm open to this being `albums` as well. Resources for Churches is only used by NS:Albums from what I can tell and is poorly named on the EE side. No reason to bring that over?

:grey_question: 

Side note, this is a fun app to work with haha